### PR TITLE
🐛 : 화면 공유중지 & 중복 수강신청 버그 수정

### DIFF
--- a/src/components/Lecture/Lecture.js
+++ b/src/components/Lecture/Lecture.js
@@ -98,7 +98,7 @@ function Lecture(props) {
         <div className="lecture_area">
             <div className="lecture_body">
                 {isBroadCast ?
-                    <TeacherScreen lecturecode={props.lecturecode} ref={teacherRef} />
+                    <TeacherScreen broadCast={setBroadCast} lecturecode={props.lecturecode} ref={teacherRef} />
                     :
                     <StudentScreen lecturecode={props.lecturecode} ref={studentRef} />
                 }

--- a/src/components/Lecture/LectureFrame.js
+++ b/src/components/Lecture/LectureFrame.js
@@ -22,22 +22,22 @@ function LectureFrame() {
             accessLecture(lecturecode)
                 .then((response) => {
                     if (response.resultCode !== "SUCCESS") {
-                        if(response.resultCode === "INVALID_LECTURE_CODE") {
-                            alert(response.result);
-                            window.location.href = "/";
-                        }
-                        else if(response.resultCode === "INVALID_ACCESS_PERMISSION") {
+                        if (response.resultCode === "INVALID_ACCESS_PERMISSION") {
                             var application = window.confirm("해당 강의에 수강신청 하시겠습니까?");
-                            if(application) {
+                            if (application) {
                                 call(`/lecture/${lecturecode}/application`, "POST")
                                     .then(() => alert("수강신청 되었습니다."))
-                                    .then(() =>  {window.location.href = "/";});
+                                    .then(() => { window.location.href = "/"; });
                             }
-                            else{
+                            else {
                                 window.location.href = "/";
                                 return false;
                             }
-                        }   
+                        }
+                        else {
+                            alert(response.result);
+                            window.location.href = "/";
+                        }
                     }
                     else {
                         setLecturename(response.result.lectureName);

--- a/src/components/Lecture/Screen/TeacherScreen.js
+++ b/src/components/Lecture/Screen/TeacherScreen.js
@@ -196,6 +196,9 @@ const TeacherScreen = forwardRef((props, ref) => {
           video: { cursor: 'always' },
           audio: { echoCancellation: true, noiseSuppression: true },
         });
+      myStream.getVideoTracks()[0].onended = function () {
+        props.broadCast(false);
+      }
       console.log("마이스트림 : ", myStream);
 
       try {


### PR DESCRIPTION
1. 브라우저의 화면 공유 인터페이스에서 공유 중지를 누르면 방송송신 화면에서 수신 화면으로 전환됩니다.
2. 이미 수강신청을 한 강의에 대해 해당 사항을 알리는 스크립트가 출력됩니다.